### PR TITLE
[Feat] 동아리 가입신청 및 승인/거절

### DIFF
--- a/src/main/java/ssu/sokdak/club/controller/ClubController.java
+++ b/src/main/java/ssu/sokdak/club/controller/ClubController.java
@@ -3,9 +3,12 @@ package ssu.sokdak.club.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import ssu.sokdak.club.dto.ClubDtos.ApproveClubMemberResponse;
 import ssu.sokdak.club.dto.ClubDtos.CreateClubRequest;
 import ssu.sokdak.club.dto.ClubDtos.CreateClubResponse;
 import ssu.sokdak.club.dto.ClubDtos.DeleteClubResponse;
+import ssu.sokdak.club.dto.ClubDtos.JoinClubResponse;
+import ssu.sokdak.club.dto.ClubDtos.RejectClubMemberResponse;
 import ssu.sokdak.club.service.ClubService;
 
 // 헤더에서 userId를 받고, 로그인 구현 후에 교체 필요
@@ -35,5 +38,40 @@ public class ClubController {
     ) {
         clubService.deleteClub(clubId, userId);
         return ResponseEntity.ok(new DeleteClubResponse(clubId, "deleted"));
+    }
+
+
+    // 동아리 가입 신청
+    @PostMapping("/{clubId}/join")
+    public ResponseEntity<JoinClubResponse> join(
+            @PathVariable Long clubId,
+            @RequestHeader("X-User-Id") Long userId
+    ) {
+        JoinClubResponse res = clubService.requestJoin(clubId, userId);
+        return ResponseEntity.ok(res);
+    }
+
+    // 동아리 가입 승인
+    @PostMapping("/{clubId}/members/{userId}/approve")
+    public ResponseEntity<ApproveClubMemberResponse> approve(
+            @PathVariable Long clubId,
+            @PathVariable("userId") Long targetUserId,
+            @RequestHeader("X-User-Id") Long managerUserId
+    ) {
+        ApproveClubMemberResponse res =
+                clubService.approveJoinRequest(clubId, managerUserId, targetUserId);
+        return ResponseEntity.ok(res);
+    }
+
+    // 동아리 가입 거절
+    @PostMapping("/{clubId}/members/{userId}/reject")
+    public ResponseEntity<RejectClubMemberResponse> reject(
+            @PathVariable Long clubId,
+            @PathVariable("userId") Long targetUserId,
+            @RequestHeader("X-User-Id") Long managerUserId
+    ) {
+        RejectClubMemberResponse res =
+                clubService.rejectJoinRequest(clubId, managerUserId, targetUserId);
+        return ResponseEntity.ok(res);
     }
 }

--- a/src/main/java/ssu/sokdak/club/domain/ClubMember.java
+++ b/src/main/java/ssu/sokdak/club/domain/ClubMember.java
@@ -32,4 +32,18 @@ public class ClubMember {
 
     @Column(name = "joined_at")
     private LocalDateTime joinedAt;
+
+    public boolean isActive() {
+        return Boolean.TRUE.equals(this.active);
+    }
+
+    public boolean isManager() {
+        return "manager".equals(this.role);
+    }
+
+    // 가입 승인 처리: active=true + joinedAt
+    public void approve(LocalDateTime approvedAt) {
+        this.active = true;
+        this.joinedAt = approvedAt;
+    }
 }

--- a/src/main/java/ssu/sokdak/club/dto/ClubDtos.java
+++ b/src/main/java/ssu/sokdak/club/dto/ClubDtos.java
@@ -8,6 +8,27 @@ public class ClubDtos {
     // 생성된 clubId 반환
     public record CreateClubResponse(Long clubId) { }
 
-    // 삭제된 clubId와 결과 문자열 ex) " ~ 동아리가 삭제되었습니다."
+    // 삭제된 clubId와 결과 문자열 ex) "~ 동아리가 삭제되었습니다."
     public record DeleteClubResponse(Long clubId, String result) { }
+
+    // 동아리 가입 신청 결과 응답
+    public record JoinClubResponse(
+            Long clubId,
+            Long userId,
+            String requestStatus
+    ) { }
+
+    // 동아리 가입 승인 결과 응답
+    public record ApproveClubMemberResponse(
+            Long clubId,
+            Long userId,
+            String requestStatus
+    ) { }
+
+    // 동아리 가입 거절 결과 응답
+    public record RejectClubMemberResponse(
+            Long clubId,
+            Long userId,
+            String requestStatus
+    ) { }
 }

--- a/src/main/java/ssu/sokdak/club/service/ClubService.java
+++ b/src/main/java/ssu/sokdak/club/service/ClubService.java
@@ -7,7 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import ssu.sokdak.club.domain.Club;
 import ssu.sokdak.club.domain.ClubMember;
+import ssu.sokdak.club.dto.ClubDtos.ApproveClubMemberResponse;
 import ssu.sokdak.club.dto.ClubDtos.CreateClubRequest;
+import ssu.sokdak.club.dto.ClubDtos.JoinClubResponse;
+import ssu.sokdak.club.dto.ClubDtos.RejectClubMemberResponse;
 import ssu.sokdak.club.repository.ClubMemberRepository;
 import ssu.sokdak.club.repository.ClubRepository;
 import ssu.sokdak.user.domain.User;
@@ -45,7 +48,7 @@ public class ClubService {
                 .club(club)
                 .user(owner)                      // 동아리 만든 manager
                 .role("manager")                  // 개설자는 관리자 역할
-                .active(true)                     // 승인 시, true로 변환
+                .active(true)                     // 이미 승인된 상태
                 .joinedAt(LocalDateTime.now())
                 .build();
         clubMemberRepository.save(manager);
@@ -60,12 +63,111 @@ public class ClubService {
                 .orElseThrow(() -> new NoSuchElementException("동아리에 속하지 않은 사용자입니다."));
 
         // 2) 권한 확인 후 manager만 삭제 가능, 보안 라이브러리 말고 403 던지도록 처리함
-        if (!"manager".equals(me.getRole())) {
+        if (!me.isManager()) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "동아리 삭제 권한이 없습니다.");
         }
 
         // 3) 멤버 → 클럽 순으로 삭제
         clubMemberRepository.deleteAllByClubId(clubId);
         clubRepository.deleteById(clubId);
+    }
+
+    // 동아리 가입 신청
+    // 신규 row 를 active=false, joinedAt=null 로 생성하여 "대기 상태"로 설정
+    public JoinClubResponse requestJoin(Long clubId, Long requesterUserId) {
+
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 동아리입니다."));
+
+        User user = userRepository.getReferenceById(requesterUserId);
+
+        if (clubMemberRepository.existsByClubIdAndUserId(clubId, requesterUserId)) {
+            throw new IllegalStateException("이미 가입했거나 가입 대기 중인 사용자입니다.");
+        }
+
+        // 가입 대기 상태 row 생성 (active=false, joinedAt=null)
+        ClubMember pending = ClubMember.builder()
+                .club(club)
+                .user(user)
+                .role("member")
+                .active(false)       // 대기 상태
+                .joinedAt(null)      // 아직 승인 전이므로 null, 승인 후 now()
+                .build();
+
+        clubMemberRepository.save(pending);
+
+        return new JoinClubResponse(
+                clubId,
+                requesterUserId,
+                "PENDING"
+        );
+    }
+
+    // 동아리 가입 승인
+    public ApproveClubMemberResponse approveJoinRequest(
+            Long clubId,
+            Long managerUserId,
+            Long targetUserId
+    ) {
+        // 1) 관리자인지 조회
+        ClubMember me = clubMemberRepository.findByClubIdAndUserId(clubId, managerUserId)
+                .orElseThrow(() -> new NoSuchElementException("동아리에 속하지 않은 사용자입니다."));
+
+        // 2) 권한 체크: manager 만 승인 가능
+        if (!me.isManager()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "동아리 가입 승인 권한이 없습니다.");
+        }
+
+        // 3) 승인 대상 멤버 조회
+        ClubMember target = clubMemberRepository.findByClubIdAndUserId(clubId, targetUserId)
+                .orElseThrow(() -> new NoSuchElementException("가입 내역이 존재하지 않습니다."));
+
+        // 4) 이미 승인된 멤버라면, 예외처리
+        if (target.isActive()) {
+            throw new IllegalStateException("이미 승인된 멤버입니다.");
+        }
+
+        // 5) 승인 처리: active=true, joinedAt=now
+        target.approve(LocalDateTime.now());
+
+        return new ApproveClubMemberResponse(
+                clubId,
+                targetUserId,
+                "APPROVED"
+        );
+    }
+
+    // 동아리 가입 거절
+    public RejectClubMemberResponse rejectJoinRequest(
+            Long clubId,
+            Long managerUserId,
+            Long targetUserId
+    ) {
+        // 1) 관리자인지 조회
+        ClubMember me = clubMemberRepository.findByClubIdAndUserId(clubId, managerUserId)
+                .orElseThrow(() -> new NoSuchElementException("동아리에 속하지 않은 사용자입니다."));
+
+        // 2) 권한 체크
+        if (!me.isManager()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "동아리 가입 거절 권한이 없습니다.");
+        }
+
+        // 3) 거절 대상 멤버 조회
+        ClubMember target = clubMemberRepository.findByClubIdAndUserId(clubId, targetUserId)
+                .orElseThrow(() -> new NoSuchElementException("가입 내역이 존재하지 않습니다."));
+
+        // 4) 이미 승인된 멤버라면, 강퇴 api 생성 후 별도 처리
+        if (target.isActive()) {
+            throw new IllegalStateException("이미 승인된 멤버는 거절할 수 없습니다.");
+        }
+
+        // 5) 대기 상태 row 삭제 = 거절
+        clubMemberRepository.delete(target);
+
+        return new RejectClubMemberResponse(
+                clubId,
+                targetUserId,
+                "REJECTED"
+        );
     }
 }


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

<!-- ex) close #10  -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- [x] : 동아리 가입 신청 및 승인/거절 기능을 추가
- [x] : 동아리 개설자는 role='manager'로 등록되며, 가입 승인/거절 권한을 가짐
- [x] : 일반 사용자는 가입 신청만 가능하며, 이미 승인된 멤버의 중복 신청은 예외 처리

## 🍰 논의사항
- 현재는 X-User-Id 헤더 기반의 비인증 구조를 유지하고, 향후 로그인 도입 시 교체 예정
<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
